### PR TITLE
Fix mistake for whether MPI is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(Thesis_REQUIRE_MPI "Require Thesis to build with MPI support" MPI_FOUND)
 if(Thesis_REQUIRE_MPI)
   find_package(MPI REQUIRED COMPONENTS CXX)
 endif()
-set(Thesis_ENABLE_MPI MPI_FOUND)
+set(Thesis_ENABLE_MPI ${MPI_FOUND})
 
 add_subdirectory(src)
 add_subdirectory(bin)


### PR DESCRIPTION
Would previously break if MPI was not available (not tested in CI) 

Fixes #27 