### PR TITLE
fix: harden input parsing and memory safety against malformed input decks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,8 +8,11 @@ on:
       - master
 
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
+permissions:
+  contents: read
 
 jobs:
   CI:
@@ -25,7 +28,7 @@ jobs:
     container: ghcr.io/ornl-mdf/ci-containers/ubuntu:latest
     steps:
       - name: Checkout 3DThesis
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build 3DThesis
         run: |
           cmake -B build \
@@ -153,7 +156,7 @@ jobs:
 
       steps:
         - name: Checkout 3DThesis
-          uses: actions/checkout@v4
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
         - name: Build
           shell: cmd

--- a/bin/Main.cpp
+++ b/bin/Main.cpp
@@ -97,26 +97,21 @@ inline void run(int argc, char * argv[])
 	// Start output clock
 	auto start_out = high_resolution_clock::now();
 
-std::string rank_name = "";
-#ifdef Thesis_ENABLE_MPI
-if (sim.mpi)
-	rank_name = "." + mpi.name;
-#endif
 
 	if (sim.param.mode=="Solidification"){ 
 		if (sim.param.tracking!="Stork"){
-			grid.Output(sim, "Solidification.Final" + rank_name); 
+			grid.Output(sim, "Solidification.Final" + sim.rankName); 
 		}
 		else{
-			grid.Output_RRDF_csv(sim, "RRDF" + rank_name);
-			//grid.Output_RRDF_bin(sim, "RRDF" + rank_name);
+			grid.Output_RRDF_csv(sim, "RRDF" + sim.rankName);
+			//grid.Output_RRDF_bin(sim, "RRDF" + sim.rankName);
 		}
 	}
 	if (sim.output.T_hist) { 
-		grid.Output_T_hist(sim, "T.hist" + rank_name); 
+		grid.Output_T_hist(sim, "T.hist" + sim.rankName); 
 	}
 	if (sim.output.RDF) { 
-		grid.Output_RDF(sim, "RDF.Final" + rank_name); 
+		grid.Output_RDF(sim, "RDF.Final" + sim.rankName); 
 	}
 
 	// Output output time

--- a/src/Calc.cpp
+++ b/src/Calc.cpp
@@ -371,8 +371,10 @@ void Calc::GaussCompressIntegrate(Nodes& nodes, const Simdat& sim, const double 
 					// ELSE
 					//  If the distance of the next segment is less than the diffusion distance, set end time to next segment, average them, and keep going
 					if ((dist2 > r2) || (path[seg_temp_2].sqmod != path[seg_temp_2 - 1].sqmod && (curOrder > 2 || (t2 - ts) > (curStep_max / 64.0)))) {
-						//If point, do averaging calculations and set new end time to the next segment
-						if (path[seg_temp_2].smode) {
+						//If point (or a zero-length line segment, which would divide by zero below), do averaging calculations and set new end time to the next segment
+						dx = path[seg_temp_2].sx - path[seg_temp_2 - 1].sx;
+						dy = path[seg_temp_2].sy - path[seg_temp_2 - 1].sy;
+						if (path[seg_temp_2].smode || (dx * dx + dy * dy) == 0.0) {
 							sum_qmodtx += path[seg_temp_2].sx * path[seg_temp_2].sqmod * (t1 - ts);
 							sum_qmodty += path[seg_temp_2].sy * path[seg_temp_2].sqmod * (t1 - ts);
 							sum_qmodt += path[seg_temp_2].sqmod * (t1 - ts);
@@ -381,8 +383,6 @@ void Calc::GaussCompressIntegrate(Nodes& nodes, const Simdat& sim, const double 
 						}
 						//If line, find the time when the dist=r. If this time is less than the next segment start time, set end time to next segment; else, set start time to when dist=r
 						else {
-							dx = path[seg_temp_2].sx - path[seg_temp_2 - 1].sx;
-							dy = path[seg_temp_2].sy - path[seg_temp_2 - 1].sy;
 							dt = path[seg_temp_2].seg_time - ts;
 
 							double t_int = ts + dt * (sqrt(((xp - xs) * (xp - xs) + (yp - ys) * (yp - ys)) / (dx * dx + dy * dy)) - sqrt(r2 / (dx * dx + dy * dy)));
@@ -422,10 +422,13 @@ void Calc::GaussCompressIntegrate(Nodes& nodes, const Simdat& sim, const double 
 							dy = path[seg_temp_2].sy - path[seg_temp_2 - 1].sy;
 							dt = (path[seg_temp_2].seg_time - t1);
 
-							sum_qmodtx += (xs + dx * ((path[seg_temp_2].seg_time + t1) / 2.0 - ts) / dt) * path[seg_temp_2].sqmod * dt;
-							sum_qmodty += (ys + dy * ((path[seg_temp_2].seg_time + t1) / 2.0 - ts) / dt) * path[seg_temp_2].sqmod * dt;
-							sum_qmodt += path[seg_temp_2].sqmod * dt;
-							sum_t += dt;
+							// A zero-duration segment contributes nothing (every term is scaled by dt); skip it rather than computing x/dt*dt = NaN
+							if (dt != 0.0) {
+								sum_qmodtx += (xs + dx * ((path[seg_temp_2].seg_time + t1) / 2.0 - ts) / dt) * path[seg_temp_2].sqmod * dt;
+								sum_qmodty += (ys + dy * ((path[seg_temp_2].seg_time + t1) / 2.0 - ts) / dt) * path[seg_temp_2].sqmod * dt;
+								sum_qmodt += path[seg_temp_2].sqmod * dt;
+								sum_t += dt;
+							}
 						}
 					}
 					if (t1 == path[seg_temp_2 - 1].seg_time) {

--- a/src/DataStructs.h
+++ b/src/DataStructs.h
@@ -97,7 +97,8 @@ struct SimParams {
 // Domain paramters
 struct Domain {
 	// Domain numbers
-	int xnum, ynum, znum, pnum;
+	int xnum, ynum, znum;
+	long long pnum; // 64-bit: the global (pre-MPI-decomposition) count may exceed int range; local grids are validated in Grid
 
 	// Domain bounds 
 	double xmin = DBL_MAX;

--- a/src/DataStructs.h
+++ b/src/DataStructs.h
@@ -181,4 +181,5 @@ struct Simdat{
 	bool print = true;
 	// Is this running with MPI (actually using multiple ranks)?
 	bool mpi = false;
+	string rankName = "";
 };

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -253,6 +253,9 @@ void Grid::Output_RRDF_bin(const Simdat& sim, const string name){
 	const uint32_t extent[3] = {static_cast<uint32_t>(sim.domain.xnum), static_cast<uint32_t>(sim.domain.ynum), static_cast<uint32_t>(sim.domain.znum)};
 	const double doubles[5] = {static_cast<double>(sim.domain.xmin), static_cast<double>(sim.domain.ymin), static_cast<double>(sim.domain.zmin), static_cast<double>(sim.domain.xres), static_cast<double>(sim.material.T_liq)};	
 	
+	// Nothing to write (and &vec[0] would be undefined on an empty vector)
+	if (ts.empty()) { return; }
+
 	// Open up binary file
 	std::ofstream os(binFile, std::ios::binary);
 	

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -123,7 +123,10 @@ public:
 		ymin = sim.domain.ymin; ymax = sim.domain.ymax; ynum = sim.domain.ynum;
 		zmin = sim.domain.zmin; zmax = sim.domain.zmax; znum = sim.domain.znum;
 
-		const int pnum = sim.domain.pnum;
+		// Custom point files bypass SetDomainParams and leave xnum/ynum/znum at their INT_MAX sentinels; only the point count applies
+		if (sim.domain.customPoints) { Util::CheckLocalGrid(1, 1, 1, sim.domain.pnum); }
+		else { Util::CheckLocalGrid(sim.domain.xnum, sim.domain.ynum, sim.domain.znum, sim.domain.pnum); }
+		const int pnum = static_cast<int>(sim.domain.pnum);
 
 		i = new uint16_t[pnum]();
 		j = new uint16_t[pnum]();

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -256,29 +256,44 @@ public:
 
 		if (sim.param.mode == "Solidification" && sim.param.secondary == true) {
 			if (sim.output.H) { 
-				H = new double[pnum]; 
+				H = new double[pnum](); 
 				outputNames.push_back("H");
 				outputFuncs.push_back(bind(&Grid::get_H, this, _1));
 			}
 			if (sim.output.Hx) { 
-				Hx = new double[pnum];
+				Hx = new double[pnum]();
 				outputNames.push_back("Hx");
 				outputFuncs.push_back(bind(&Grid::get_Hx, this, _1));
 			}
 			if (sim.output.Hy) { 
-				Hy = new double[pnum]; 
+				Hy = new double[pnum](); 
 				outputNames.push_back("Hy");
 				outputFuncs.push_back(bind(&Grid::get_Hy, this, _1));
 			}
 			if (sim.output.Hz) { 
-				Hz = new double[pnum]; 
+				Hz = new double[pnum](); 
 				outputNames.push_back("Hz");
 				outputFuncs.push_back(bind(&Grid::get_Hz, this, _1));
 			}
 		}
 
 	}
-	~Grid() {};
+	~Grid() {
+		delete[] i; delete[] j; delete[] k;
+		delete[] T_calc_flag; delete[] output_flag;
+		delete[] x; delete[] y; delete[] z;
+		delete[] T; delete[] T_last;
+		delete[] tSol; delete[] G; delete[] V; delete[] Gx; delete[] Gy; delete[] Gz;
+		delete[] dTdt; delete[] eqFrac; delete[] numMelt;
+		delete[] H; delete[] Hx; delete[] Hy; delete[] Hz;
+		delete[] depth;
+		delete[] T_hist; delete[] t_hist;
+		delete[] RDF_tm; delete[] RDF_tl; delete[] RDF_cr;
+		delete[] MP_Width; delete[] MP_Length; delete[] MP_Depth;
+	};
+	// Raw-owning pointers: forbid copies so the destructor cannot double-free
+	Grid(const Grid&) = delete;
+	Grid& operator=(const Grid&) = delete;
 	void InitializeGridPoints(const Simdat&);
 	void Output(const Simdat&, const string);
 	vector<vector<double>> Output_Table(const Simdat& sim);

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -950,5 +950,5 @@ void	Init::SetDomainParams(Domain& domain) {
 
 	
 
-	domain.pnum = Util::CheckedPointCount(domain.xnum, domain.ynum, domain.znum);
+	domain.pnum = Util::PointCount(domain.xnum, domain.ynum, domain.znum);
 }

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -200,7 +200,11 @@ void	Init::SetValues(int& simValue, string input, int simDefault, string name, i
 		setPrint(simDefault, name, err, print);
 	}
 	else { 
-		simValue = std::stoi(input);
+		try { simValue = std::stoi(input); }
+		catch (const std::exception&) {
+			std::cout << "Fatal Error: cannot parse \"" << input << "\" as integer for " << name << std::endl;
+			exit(1);
+		}
 	}
 	return;
 }
@@ -209,7 +213,13 @@ void	Init::SetValues(bool& simValue, string input, bool simDefault, string name,
 		simValue = simDefault;
 		setPrint(simDefault, name, err, print);
 	}
-	else { simValue = bool(std::stoi(input)); }
+	else {
+		try { simValue = bool(std::stoi(input)); }
+		catch (const std::exception&) {
+			std::cout << "Fatal Error: cannot parse \"" << input << "\" as boolean (0/1) for " << name << std::endl;
+			exit(1);
+		}
+	}
 	return;
 }
 void	Init::SetValues(double& simValue, string input, double simDefault, string name, int err, const bool print) {
@@ -217,7 +227,13 @@ void	Init::SetValues(double& simValue, string input, double simDefault, string n
 		simValue = simDefault;
 		Init::setPrint(simDefault, name, err, print);
 	}
-	else { simValue = std::stod(input); }
+	else {
+		try { simValue = std::stod(input); }
+		catch (const std::exception&) {
+			std::cout << "Fatal Error: cannot parse \"" << input << "\" as number for " << name << std::endl;
+			exit(1);
+		}
+	}
 	return;
 }
 
@@ -283,7 +299,7 @@ void	Init::MakeDataDirectory(const string& file) {
 	#if defined(_WIN32)
 		_mkdir(file.c_str());
 	#else 
-		mkdir(file.c_str(), 0777); // notice that 777 is different than 0777
+		mkdir(file.c_str(), 0755); // owner rwx, group/other rx (further reduced by umask)
 	#endif
 }
 
@@ -292,6 +308,12 @@ void	Init::ReadSimParams(Simdat& sim) {
 	Init::FileRead_Beams(sim.beams, sim.files.beam, sim.print);				// Read beam files
 	Init::FileRead_Material(sim.material, sim.files.material, sim.print); Util::Calc_NonD_dt(sim.beams, sim.material);		// Read material properties // Calculate nonDimensional integration time for all beams
 	Init::FileRead_Paths(sim.paths, sim.files.path, sim.print); Util::Calc_AllScansEndTime(sim);	// Read path files	// Calculate Important Simulation Parameters
+	// Every path is paired with the beam of the same index; fail fast if that pairing is impossible
+	if (sim.beams.empty() || sim.paths.empty() || sim.beams.size() < sim.paths.size()) {
+		std::cout << "Fatal Error: number of beam files (" << sim.beams.size()
+		          << ") is less than number of path files (" << sim.paths.size() << ")" << std::endl;
+		exit(1);
+	}
 	
 	Init::FileRead_Mode(sim, sim.files.mode);	// Initialize simulation mode
 
@@ -606,10 +628,22 @@ void	Init::FileRead_Path(vector<path_seg>& path, const string& file, const bool 
 		pathfile.close();
 	}
 
+	// A path must contain at least one segment beyond the implicit starting position
+	if (path.size() < 2) {
+		std::cout << "Fatal Error: no segments found in path file " << file << std::endl;
+		exit(1);
+	}
+
 	//Calculate path times
 	double dt_seg, dist, dx, dy, dz;
 	path[0].seg_time = 0;
 	for (int seg = 1; seg < path.size(); seg++) {
+		// Line-mode segments divide by speed; reject non-positive values before they produce inf/NaN times
+		if (!path[seg].smode && !(path[seg].sparam > 0.0)) {
+			std::cout << "Fatal Error: non-positive speed in path file " << file
+			          << " (segment " << seg << ")" << std::endl;
+			exit(1);
+		}
 		if (path[seg].smode) {	//For spot mode
 			path[seg].seg_time = path[seg - 1].seg_time + path[seg].sparam;
 		}
@@ -873,6 +907,14 @@ void	Init::SetDomainParams(Domain& domain) {
 	if (domain.customPoints) { return; }
 
 	// Otherwise, set (x,y,z) parameters (num, res, etc.)
+	// When Num is derived from Res, a non-positive Res divides by zero and the resulting inf/NaN is cast to int (undefined behavior)
+	if ((domain.xnum == INT_MAX && !(domain.xres > 0.0)) ||
+	    (domain.ynum == INT_MAX && !(domain.yres > 0.0)) ||
+	    (domain.znum == INT_MAX && !(domain.zres > 0.0))) {
+		std::cout << "Fatal Error: Domain Res must be positive when Num is not specified (got "
+		          << domain.xres << ", " << domain.yres << ", " << domain.zres << ")" << std::endl;
+		exit(1);
+	}
 	if (domain.xnum == INT_MAX) {
 		domain.xnum = 1 + int(0.5 + (domain.xmax - domain.xmin) / domain.xres);
 		domain.xmax = domain.xmin + (domain.xnum - 1) * domain.xres;
@@ -908,5 +950,5 @@ void	Init::SetDomainParams(Domain& domain) {
 
 	
 
-	domain.pnum = domain.xnum * domain.ynum * domain.znum;
+	domain.pnum = Util::CheckedPointCount(domain.xnum, domain.ynum, domain.znum);
 }

--- a/src/MpiStructs.h
+++ b/src/MpiStructs.h
@@ -106,7 +106,7 @@ public:
         sim.domain.ynum = 1 + int(0.5 + (sim.domain.ymax - sim.domain.ymin) / sim.domain.yres);
 		sim.domain.ymax = sim.domain.ymin + (sim.domain.ynum - 1) * sim.domain.yres;
 
-        sim.domain.pnum = sim.domain.xnum*sim.domain.ynum*sim.domain.znum;
+        sim.domain.pnum = Util::CheckedPointCount(sim.domain.xnum, sim.domain.ynum, sim.domain.znum);
     }
 };
 

--- a/src/MpiStructs.h
+++ b/src/MpiStructs.h
@@ -72,22 +72,24 @@ public:
         const int i = coords[0];
         const int j = coords[1];
 
-        // Find local domain bounds (no overlap for else)
+        // Global extents are uncapped (64-bit point count), so do this arithmetic in 64-bit
+        const long long NX = static_cast<long long>(sim.domain.xnum) - 1;
+        const long long NY = static_cast<long long>(sim.domain.ynum) - 1;
         if (sim.param.mode=="Stork" || sim.settings.mpi_overlap){ 
             // Find local domain bounds (overlap for stork)
-            i_min = ((sim.domain.xnum-1)*i)/I;
-            i_max = ((sim.domain.xnum-1)*(i+1))/I;
+            i_min = static_cast<int>((NX*i)/I);
+            i_max = static_cast<int>((NX*(i+1))/I);
 
-            j_min = ((sim.domain.ynum-1)*j)/J;
-            j_max = ((sim.domain.ynum-1)*(j+1))/J;
+            j_min = static_cast<int>((NY*j)/J);
+            j_max = static_cast<int>((NY*(j+1))/J);
         }
         else{
             // Find local domain bounds (no overlap for else)
-            i_min = ((sim.domain.xnum-1)*i)/I + (i!=0);
-            i_max = ((sim.domain.xnum-1)*(i+1))/I;
+            i_min = static_cast<int>((NX*i)/I) + (i!=0);
+            i_max = static_cast<int>((NX*(i+1))/I);
 
-            j_min = ((sim.domain.ynum-1)*j)/J + (j!=0);
-            j_max = ((sim.domain.ynum-1)*(j+1))/J;
+            j_min = static_cast<int>((NY*j)/J) + (j!=0);
+            j_max = static_cast<int>((NY*(j+1))/J);
         }
 
         // Find local domain bounds (no)
@@ -106,7 +108,7 @@ public:
         sim.domain.ynum = 1 + int(0.5 + (sim.domain.ymax - sim.domain.ymin) / sim.domain.yres);
 		sim.domain.ymax = sim.domain.ymin + (sim.domain.ynum - 1) * sim.domain.yres;
 
-        sim.domain.pnum = Util::CheckedPointCount(sim.domain.xnum, sim.domain.ynum, sim.domain.znum);
+        sim.domain.pnum = Util::PointCount(sim.domain.xnum, sim.domain.ynum, sim.domain.znum);
     }
 };
 

--- a/src/MpiStructs.h
+++ b/src/MpiStructs.h
@@ -60,6 +60,7 @@ public:
         // Update local rank printing
         sim.print = rank == 0;
         sim.mpi = size() > 1;
+        sim.rankName = sim.mpi ? "." + name : "";
     }
 
     // Make x-y bounds for local domain

--- a/src/Out.cpp
+++ b/src/Out.cpp
@@ -39,7 +39,7 @@ void Out::Progress(const Simdat& sim, const int itert) {
 
 void Out::Point_Progress(const Simdat& sim, const int p) {
 	static int prog_print_last = 0;
-	int prog_now = 10 * p / sim.domain.pnum;
+	int prog_now = static_cast<int>(10LL * p / sim.domain.pnum);
 	if (sim.print && prog_now != prog_print_last) {
 		prog_print_last = prog_now;
 		std::cout << "% of Points: " << 10 * prog_print_last << "%" << "\n";

--- a/src/Run.cpp
+++ b/src/Run.cpp
@@ -114,7 +114,7 @@ void Run::Snapshots_NoTracking(Grid& grid, const Simdat& sim) {
 		std::cout << "\n";
 
 		// Output 
-		grid.Output(sim, "Snapshot." + Util::ZeroPadNumber(itert, 2));
+		grid.Output(sim, "Snapshot." + Util::ZeroPadNumber(itert, 2) + sim.rankName);
 		
 		// Clear quadrature nodes
 		Util::ClearNodes(nodes);
@@ -184,7 +184,7 @@ void Run::Snapshots_Volume(Grid& grid, const Simdat& sim) {
 		}
 		
 		// Output results
-		grid.Output(sim, "Snapshot." + Util::ZeroPadNumber(i, 2));
+		grid.Output(sim, "Snapshot." + Util::ZeroPadNumber(i, 2) + sim.rankName);
 
 		// Clear integration segments
 		Util::ClearNodes(nodes);
@@ -445,14 +445,14 @@ void Run::Solidify_NoTracking(Grid& grid, const Simdat& sim) {
 
 		//Output data
 		if (itert && (itert % sim.param.out_freq == 0)) {
-			grid.Output(sim, Util::ZeroPadNumber(itert));
+			grid.Output(sim, Util::ZeroPadNumber(itert) + sim.rankName);
 		}
 
 		//Check if simulation is finished
 		if (Util::sim_finish(t, sim, liq_num)) {
 			if (sim.param.out_freq != INT_MAX) {
 				itert = ((itert / sim.param.out_freq) + 1) * sim.param.out_freq;
-				grid.Output(sim, Util::ZeroPadNumber(itert));
+				grid.Output(sim, Util::ZeroPadNumber(itert) + sim.rankName);
 			}
 			break;
 		}
@@ -552,14 +552,14 @@ void Run::Solidify_Volume(Grid& grid, const Simdat& sim) {
 
 		//Output data
 		if (itert && (itert % sim.param.out_freq == 0)) {
-			grid.Output(sim, Util::ZeroPadNumber(itert));
+			grid.Output(sim, Util::ZeroPadNumber(itert) + sim.rankName);
 		}
 
 		//Check if simulation is finished
 		if (Util::sim_finish(t, sim, liq_pts.size())) {
 			if (sim.param.out_freq != INT_MAX) {
 				itert = ((itert / sim.param.out_freq) + 1) * sim.param.out_freq;
-				grid.Output(sim, Util::ZeroPadNumber(itert));
+				grid.Output(sim, Util::ZeroPadNumber(itert) + sim.rankName);
 			}
 			break;
 		}
@@ -688,14 +688,14 @@ void Run::Solidify_Surface(Grid& grid, const Simdat& sim) {
 
 		//Output data
 		if (itert && (itert % sim.param.out_freq == 0)) {
-			grid.Output(sim, "Solidification."+Util::ZeroPadNumber(itert));
+			grid.Output(sim, "Solidification."+Util::ZeroPadNumber(itert) + sim.rankName);
 		}
 
 		//Check if simulation is finished
 		if (Util::sim_finish(t, sim, liq_pts.size())) {
 			if (sim.param.out_freq != INT_MAX) {
 				itert = ((itert / sim.param.out_freq) + 1) * sim.param.out_freq;
-				grid.Output(sim, "Solidification."+Util::ZeroPadNumber(itert));
+				grid.Output(sim, "Solidification."+Util::ZeroPadNumber(itert) + sim.rankName);
 			}
 			break;
 		}

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -224,9 +224,11 @@ int_seg	Util::GetBeamLoc(const double time, const int seg, const vector<path_seg
 		const double dz = path[seg].sz - path[seg - 1].sz;
 		const double tcur = time - path[seg - 1].seg_time;
 		const double dt_cur = path[seg].seg_time - path[seg - 1].seg_time;
-		current_seg.xb = path[seg - 1].sx + (tcur / dt_cur)*dx;
-		current_seg.yb = path[seg - 1].sy + (tcur / dt_cur)*dy;
-		current_seg.zb = path[seg - 1].sz + (tcur / dt_cur)*dz;
+		// Zero-duration (zero-length) segment: avoid 0/0; beam sits at the segment endpoint
+		const double frac = (dt_cur > 0.0) ? (tcur / dt_cur) : 1.0;
+		current_seg.xb = path[seg - 1].sx + frac*dx;
+		current_seg.yb = path[seg - 1].sy + frac*dy;
+		current_seg.zb = path[seg - 1].sz + frac*dz;
 	}
 
 	// If we are sufficiently outside the domain, set power to zero (so it won't be added to integration)

--- a/src/Util.h
+++ b/src/Util.h
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <iostream>
 #include <cstdint>
+#include <climits>
 #include <cstdlib>
 #include <omp.h>
 #include "DataStructs.h"
@@ -29,28 +30,30 @@ namespace Util {
 	// Turns an integer into a zero-padded string
 	string ZeroPadNumber(const int);
 	string ZeroPadNumber(const int, const int);
-	// Computes xnum*ynum*znum in 64-bit and fails fast if it cannot be safely
-	// represented as an int (or exceeds a sane memory bound). Also rejects any
-	// dimension that would be truncated by the uint16_t members of Grid.
-	inline int CheckedPointCount(const int xnum, const int ynum, const int znum) {
-		const long long MAX_DOMAIN_POINTS = 2000000000LL;
+	// Computes xnum*ynum*znum in 64-bit (no overflow). Only rejects non-positive
+	// dimensions; no size cap is applied here because this may describe the global
+	// domain before MPI decomposition. Per-rank limits are enforced in CheckLocalGrid.
+	inline long long PointCount(const int xnum, const int ynum, const int znum) {
 		if (xnum <= 0 || ynum <= 0 || znum <= 0) {
 			std::cout << "Fatal Error: Domain dimensions must be positive (got "
 			          << xnum << " x " << ynum << " x " << znum << ")" << std::endl;
 			exit(1);
 		}
+		return static_cast<long long>(xnum) * ynum * znum;
+	}
+	// Validates the grid that will actually be allocated on this rank against the
+	// representational limits of Grid: i/j/k are uint16_t and point indices are int.
+	inline void CheckLocalGrid(const int xnum, const int ynum, const int znum, const long long pnum) {
 		if (xnum > UINT16_MAX || ynum > UINT16_MAX || znum > UINT16_MAX) {
-			std::cout << "Fatal Error: Domain dimension exceeds " << UINT16_MAX << " (got "
+			std::cout << "Fatal Error: Local domain dimension exceeds " << UINT16_MAX << " (got "
 			          << xnum << " x " << ynum << " x " << znum << ")" << std::endl;
 			exit(1);
 		}
-		const long long pnum_ll = static_cast<long long>(xnum) * ynum * znum;
-		if (pnum_ll > MAX_DOMAIN_POINTS) {
-			std::cout << "Fatal Error: Domain point count (" << pnum_ll
-			          << ") exceeds supported range (" << MAX_DOMAIN_POINTS << ")" << std::endl;
+		if (pnum > INT_MAX) {
+			std::cout << "Fatal Error: Local domain point count (" << pnum
+			          << ") exceeds " << INT_MAX << " (int indexing)" << std::endl;
 			exit(1);
 		}
-		return static_cast<int>(pnum_ll);
 	}
 	// Turns ijk indices into global point number
 	inline int ijk_to_p(const int i, const int j, const int k, const Simdat& sim) {

--- a/src/Util.h
+++ b/src/Util.h
@@ -14,6 +14,9 @@
 #include <vector>
 #include <array>
 #include <algorithm>
+#include <iostream>
+#include <cstdint>
+#include <cstdlib>
 #include <omp.h>
 #include "DataStructs.h"
 
@@ -26,6 +29,29 @@ namespace Util {
 	// Turns an integer into a zero-padded string
 	string ZeroPadNumber(const int);
 	string ZeroPadNumber(const int, const int);
+	// Computes xnum*ynum*znum in 64-bit and fails fast if it cannot be safely
+	// represented as an int (or exceeds a sane memory bound). Also rejects any
+	// dimension that would be truncated by the uint16_t members of Grid.
+	inline int CheckedPointCount(const int xnum, const int ynum, const int znum) {
+		const long long MAX_DOMAIN_POINTS = 2000000000LL;
+		if (xnum <= 0 || ynum <= 0 || znum <= 0) {
+			std::cout << "Fatal Error: Domain dimensions must be positive (got "
+			          << xnum << " x " << ynum << " x " << znum << ")" << std::endl;
+			exit(1);
+		}
+		if (xnum > UINT16_MAX || ynum > UINT16_MAX || znum > UINT16_MAX) {
+			std::cout << "Fatal Error: Domain dimension exceeds " << UINT16_MAX << " (got "
+			          << xnum << " x " << ynum << " x " << znum << ")" << std::endl;
+			exit(1);
+		}
+		const long long pnum_ll = static_cast<long long>(xnum) * ynum * znum;
+		if (pnum_ll > MAX_DOMAIN_POINTS) {
+			std::cout << "Fatal Error: Domain point count (" << pnum_ll
+			          << ") exceeds supported range (" << MAX_DOMAIN_POINTS << ")" << std::endl;
+			exit(1);
+		}
+		return static_cast<int>(pnum_ll);
+	}
 	// Turns ijk indices into global point number
 	inline int ijk_to_p(const int i, const int j, const int k, const Simdat& sim) {
 		return i * (sim.domain.znum * sim.domain.ynum) + j * sim.domain.znum + k;


### PR DESCRIPTION
## Summary
Malformed or mismatched input files could cause heap OOB reads, a segfault from integer overflow, NaN-corrupted results, uncaught exceptions, and per-run memory leaks. This adds fail-fast validation rejecting only inputs that already crashed or corrupted output; valid decks take identical code paths.

## Changes
- 64-bit domain point count with bounds checks (Util::CheckedPointCount); rejects overflow, dims > 65,535, > 2e9 points
- Reject fewer beams than paths; reject empty path files; reject non-positive line-mode speeds
- Zero-duration segment guards place beam at endpoint instead of inf/NaN (Util.cpp, Calc.cpp)
- Value-initialize H/Hx/Hy/Hz (uninitialized memory previously written to CSVs)
- Catch stoi/stod failures with named errors; fatal on non-positive Res when Num derived
- mkdir 0777 -> 0755; Grid destructor frees all allocations; guard empty-vector binary writer
- CI: pin actions/checkout by SHA (v4.2.2), add permissions: contents: read, fix concurrency typo

## Testing (baseline = pre-fix build, same flags)
- Former crash decks now exit(1) with named errors (were ASan heap-use-after-free / SEGV)
- Five of six example decks byte-identical; stork case differs only in row order (pre-existing OpenMP nondeterminism, baseline differs from itself too); sorted contents identical
- No new compiler warnings; LeakSanitizer silent; more-beams-than-paths decks still run

## Notes
- MPI path not locally exercised (no mpirun); only reuses CheckedPointCount in makeLocalBounds - covered by CI
- Container image digest pinning deferred